### PR TITLE
better error message for --format

### DIFF
--- a/cite/__init__.py
+++ b/cite/__init__.py
@@ -23,7 +23,11 @@ parser.add_argument(
     "--format",
     default="text",
     required=False,
-    help='return citation data in specified format: "rdf-xml", "turtle", "citeproc-json", "citeproc-json-ish", "text" (Default), "ris", "bibtex" , "crossref-xml", "datacite-xml","bibentry", or "crossref-tdm"',
+    choices=[
+        "text", "rdf-xml", "turtle", "citeproc-json", "citeproc-json-ish", "ris", "bibtex" , "crossref-xml",
+        "datacite-xml", "bibentry", "crossref-tdm",
+    ],
+    help='return citation data in specified format: "rdf-xml", "turtle", "citeproc-json", "citeproc-json-ish", "text" (Default), "ris", "bibtex" , "crossref-xml", "datacite-xml", "bibentry", or "crossref-tdm"',
 )
 parser.add_argument(
     "--bibtex",


### PR DESCRIPTION
I mistyped the --format argument which caused this traceback:

```
Traceback (most recent call last):
  File "/Users/simon/.pyenv/versions/3.7.0/bin/cite", line 11, in <module>
    sys.exit(main())
  File "/Users/simon/.pyenv/versions/3.7.0/lib/python3.7/site-packages/cite/__init__.py", line 61, in main
    result = cn.content_negotiation(doi, format=args.format)
  File "/Users/simon/.pyenv/versions/3.7.0/lib/python3.7/site-packages/habanero/cn/cn.py", line 76, in content_negotiation
    return CNRequest(url, ids, format, style, locale, **kwargs)
  File "/Users/simon/.pyenv/versions/3.7.0/lib/python3.7/site-packages/habanero/cnrequest.py", line 26, in CNRequest
    return make_request(url, ids[0], format, style, locale, **kwargs)
  File "/Users/simon/.pyenv/versions/3.7.0/lib/python3.7/site-packages/habanero/cnrequest.py", line 38, in make_request
    type = cn_format_headers[format]
KeyError: 'vivtex'
```

This PR uses argparse's `choices` to do some rudimentary error checking, so now the message is:

```
cite: error: argument --format: invalid choice: 'vivtex' (choose from 'text', 'rdf-xml', 'turtle', 'citeproc-json', 'citeproc-json-ish', 'ris', 'bibtex', 'crossref-xml', 'datacite-xml', 'bibentry', 'crossref-tdm')
```